### PR TITLE
Add Python wrapper for mkepicam

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 This repository holds scripts for automatically capturing evaluation images from an image sensor. Use `setup.sh` to prepare the environment and see `spec_picamcapture.md` for a description of the intended functionality.
 
+The `mkepicam_wrapper/` directory contains a small [pybind11](https://pybind11.readthedocs.io/) wrapper for the C++ `mkepicam` library so that camera control can be performed from Python.
+

--- a/mkepicam_wrapper/__init__.py
+++ b/mkepicam_wrapper/__init__.py
@@ -1,0 +1,15 @@
+"""Python wrapper for the mkepicam C++ library using pybind11."""
+
+from importlib import import_module
+
+try:
+    _mod = import_module('mkepicam_pybind')
+except ImportError as e:
+    raise ImportError(
+        'mkepicam_pybind module not found. Run setup.py to build it.') from e
+
+Camera = _mod.Camera
+CameraInfo = _mod.CameraInfo
+find_camera = _mod.find_camera
+
+__all__ = ['Camera', 'CameraInfo', 'find_camera']

--- a/mkepicam_wrapper/mkepicam_pybind.cpp
+++ b/mkepicam_wrapper/mkepicam_pybind.cpp
@@ -1,0 +1,29 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "mkepicam/mkepicam.h"
+
+namespace py = pybind11;
+
+namespace mkepicam_py {
+
+PYBIND11_MODULE(mkepicam_pybind, m) {
+    using namespace mkepicam;
+
+    py::class_<camera_info>(m, "CameraInfo")
+        .def_readonly("width", &camera_info::width)
+        .def_readonly("height", &camera_info::height)
+        .def_readonly("name", &camera_info::name);
+
+    py::class_<Camera>(m, "Camera", py::nodelete)
+        .def("get_camera_info", &Camera::get_camera_info)
+        .def("open", &Camera::open)
+        .def("close", &Camera::close)
+        .def("set_exposure", &Camera::set_exposure)
+        .def("set_gain", &Camera::set_gain)
+        .def("set_flash", &Camera::set_flash);
+
+    m.def("find_camera", py::overload_cast<const char *>(&find_camera),
+          py::return_value_policy::reference);
+}
+
+} // namespace mkepicam_py

--- a/mkepicam_wrapper/setup.py
+++ b/mkepicam_wrapper/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup, Extension
+import pybind11
+import os
+
+include_dirs = [pybind11.get_include(), os.path.join('..', 'mkepicam')]
+
+ext_modules = [
+    Extension(
+        'mkepicam_pybind',
+        ['mkepicam_pybind.cpp'],
+        include_dirs=include_dirs,
+        language='c++',
+        extra_compile_args=['-std=c++11'],
+        libraries=['mkepicam']
+    )
+]
+
+setup(
+    name='mkepicam_pybind',
+    version='0.1',
+    ext_modules=ext_modules,
+    zip_safe=False,
+)

--- a/spec_picamcapture.md
+++ b/spec_picamcapture.md
@@ -10,6 +10,7 @@ picamcapture is intended to automate the capture of evaluation images for image 
 - Command line interface for starting a capture session.
 - Optional configuration file to store default parameters.
 - Logging of capture parameters and camera metadata.
+- Python wrapper for the C++ `mkepicam` library via `pybind11`.
 
 ## Directory Layout
 
@@ -27,6 +28,7 @@ The project uses Python 3. Typical dependencies include:
 - `opencv-python` for camera access and image processing
 - `pillow` for image format conversions
 - `libcamera-tools` for low level control on systems that support it
+- `pybind11` to build the wrapper for the C++ `mkepicam` library
 
 See `setup.sh` for an example installation script.
 


### PR DESCRIPTION
## Summary
- add `mkepicam_wrapper` module with pybind11 bindings
- mention wrapper in README and spec

## Testing
- `python3 -m py_compile mkepicam_wrapper/setup.py mkepicam_wrapper/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_683fc72f9194833381b40cdcb7b1f8b2