### PR TITLE
Update to C++14 and adjust docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository holds scripts for automatically capturing evaluation images from
 The `mkepicam_wrapper/` directory contains a small [pybind11](https://pybind11.readthedocs.io/) wrapper for the C++ `mkepicam` library so that camera control can be performed from Python.
 
 
-To build the wrapper run:
+To build the wrapper you need a compiler that supports **C++14**. Run:
 
 ```bash
 cd mkepicam_wrapper

--- a/mkepicam_wrapper/setup.py
+++ b/mkepicam_wrapper/setup.py
@@ -10,7 +10,7 @@ ext_modules = [
         ['mkepicam_pybind.cpp'],
         include_dirs=include_dirs,
         language='c++',
-        extra_compile_args=['-std=c++11'],
+        extra_compile_args=['-std=c++14'],
         libraries=['mkepicam']
     )
 ]

--- a/spec_picamcapture.md
+++ b/spec_picamcapture.md
@@ -34,7 +34,7 @@ See `setup.sh` for an example installation script.
 
 ## mkepicam_wrapper Usage
 
-To build the pybind11 wrapper run:
+To build the pybind11 wrapper you need a compiler that supports **C++14**. Run:
 
 ```bash
 cd mkepicam_wrapper


### PR DESCRIPTION
## Summary
- update compile flags in `mkepicam_wrapper/setup.py` to use C++14
- document that building the wrapper requires a C++14 compiler in README and spec

## Testing
- `python mkepicam_wrapper/setup.py build_ext --inplace` *(fails: ModuleNotFoundError: No module named 'setuptools')*

------
https://chatgpt.com/codex/tasks/task_e_683fcf0ab610833386b297d915ceb7d8