### PR TITLE
README: clarify PYTHONPATH usage for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ cd mkepicam_wrapper
 python setup.py build_ext --inplace
 ```
 
-Once built, try the sample capture program:
+Once built, try the sample capture program. Make sure the repository root is in
+`PYTHONPATH` so that Python can locate the wrapper module:
 
 ```bash
-python ../examples/simple_capture.py
+export PYTHONPATH=$(pwd)
+python examples/simple_capture.py
 ```


### PR DESCRIPTION
## Summary
- update README instructions for running example to include `PYTHONPATH`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a49368208333b723d2cfdd6fb8bd