### PR TITLE
README: clarify example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ To build the wrapper you need a compiler that supports **C++14**. Run:
 ```bash
 cd mkepicam_wrapper
 python setup.py build_ext --inplace
+cd ..
 ```
 
-Once built, try the sample capture program:
+Once built, try the sample capture program. Be sure to include the repository
+root in `PYTHONPATH` so that Python can locate the wrapper module:
 
 ```bash
-python ../examples/simple_capture.py
+export PYTHONPATH=$(pwd)
+python examples/simple_capture.py
 ```


### PR DESCRIPTION
## Summary
- clarify build step instructions
- ensure example is run from repo root with PYTHONPATH set

## Testing
- `python examples/simple_capture.py` *(fails: mkepicam_wrapper not built)*

------
https://chatgpt.com/codex/tasks/task_e_6840a49368208333b723d2cfdd6fb8bd