### PR TITLE
Fix wrapper import

### DIFF
--- a/mkepicam_wrapper/__init__.py
+++ b/mkepicam_wrapper/__init__.py
@@ -3,7 +3,7 @@
 from importlib import import_module
 
 try:
-    _mod = import_module('mkepicam_pybind')
+    _mod = import_module('.mkepicam_pybind', package=__name__)
 except ImportError as e:
     raise ImportError(
         'mkepicam_pybind module not found. Run setup.py to build it.') from e


### PR DESCRIPTION
## Summary
- fix import path in mkepicam wrapper

## Testing
- `python3 mkepicam_wrapper/setup.py build_ext --inplace` *(fails: cannot find -lmkepicam)*
- `python3 examples/simple_capture.py` *(fails: mkepicam_wrapper is not built)*

------
https://chatgpt.com/codex/tasks/task_e_6842e60741388333b8c2a267e7a9f58e