### PR TITLE
Update README with library path instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ python setup.py build_ext --inplace
 cd ..
 ```
 
+Make sure that `libmkepicam.so` can be located by the dynamic linker. You may
+copy or symlink the library into a standard directory such as `/usr/local/lib`.
+If the library resides elsewhere, add that directory to `LD_LIBRARY_PATH`:
+
+```bash
+export LD_LIBRARY_PATH=/path/to/lib:$LD_LIBRARY_PATH
+```
+
 Once built, try the sample capture program. Be sure to include the repository
 root in `PYTHONPATH` so that Python can locate the wrapper module:
 


### PR DESCRIPTION
## Summary
- update README with libmkepicam.so placement instructions
- show how to set `LD_LIBRARY_PATH` if not in standard locations

## Testing
- `python examples/simple_capture.py` *(fails: mkepicam_wrapper is not built)*

------
https://chatgpt.com/codex/tasks/task_e_6842eb63b544833390b23f3978f4e72d