### PR TITLE
Update wrapper build to use static lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,14 @@ pip install -r requirements.txt
 ```
 
 
-To build the wrapper you need a compiler that supports **C++14**. Run:
+To build the wrapper you need a compiler that supports **C++14**.
+`libmkepicam.a` へのパスを `MKEPICAM_LIB` 環境変数で指定してからビルドします。
 
 ```bash
+export MKEPICAM_LIB=/path/to/libmkepicam.a
 cd mkepicam_wrapper
 python setup.py build_ext --inplace
 cd ..
-```
-
-Make sure that `libmkepicam.so` can be located by the dynamic linker. You may
-copy or symlink the library into a standard directory such as `/usr/local/lib`.
-If the library resides elsewhere, add that directory to `LD_LIBRARY_PATH`:
-
-```bash
-export LD_LIBRARY_PATH=/path/to/lib:$LD_LIBRARY_PATH
 ```
 
 Once built, try the sample capture program. Be sure to include the repository

--- a/mkepicam_wrapper/setup.py
+++ b/mkepicam_wrapper/setup.py
@@ -4,6 +4,13 @@ import os
 
 include_dirs = [pybind11.get_include(), os.path.join('..', 'mkepicam')]
 
+# MKEPICAM_LIB 環境変数で mkepicam の静的ライブラリを指定する。
+lib_path = os.environ.get('MKEPICAM_LIB')
+if not lib_path:
+    raise OSError(
+        'MKEPICAM_LIB 環境変数が設定されていません。libmkepicam.a のパスを指定してください。'
+    )
+
 ext_modules = [
     Extension(
         'mkepicam_pybind',
@@ -11,7 +18,8 @@ ext_modules = [
         include_dirs=include_dirs,
         language='c++',
         extra_compile_args=['-std=c++14'],
-        libraries=['mkepicam']
+        # 静的ライブラリをリンクする
+        extra_objects=[lib_path]
     )
 ]
 

--- a/spec_picamcapture.md
+++ b/spec_picamcapture.md
@@ -34,9 +34,11 @@ See `setup.sh` for an example installation script.
 
 ## mkepicam_wrapper Usage
 
-To build the pybind11 wrapper you need a compiler that supports **C++14**. Run:
+To build the pybind11 wrapper you need a compiler that supports **C++14**.
+`libmkepicam.a` のパスを `MKEPICAM_LIB` に設定してからビルドします。
 
 ```bash
+export MKEPICAM_LIB=/path/to/libmkepicam.a
 cd mkepicam_wrapper
 python setup.py build_ext --inplace
 ```


### PR DESCRIPTION
## Summary
- link mkepicam_wrapper against a static library specified with `MKEPICAM_LIB`
- document the environment variable in README and spec

## Testing
- `python mkepicam_wrapper/setup.py build_ext --inplace` *(fails: MKEPICAM_LIB not set)*

------
https://chatgpt.com/codex/tasks/task_e_6842efdcb20083338d1335722cfda0ad