### PR TITLE
Update static build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ To build the wrapper you need a compiler that supports **C++14**. Run:
 ```bash
 cd mkepicam_wrapper
 python setup.py build_ext --inplace
+# for static builds specify the library path
+MKEPICAM_LIB=/path/to/libmkepicam.a python setup.py build_ext --inplace
 cd ..
 ```
 
-Make sure that `libmkepicam.so` can be located by the dynamic linker. You may
-copy or symlink the library into a standard directory such as `/usr/local/lib`.
-If the library resides elsewhere, add that directory to `LD_LIBRARY_PATH`:
+Make sure that the `mkepicam` library can be located. When using the shared library (`libmkepicam.so`) copy or symlink it into a standard directory such as `/usr/local/lib` or add that directory to `LD_LIBRARY_PATH`. When linking the static library (`libmkepicam.a`) specify its path with `MKEPICAM_LIB` as shown above.
 
 ```bash
 export LD_LIBRARY_PATH=/path/to/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
## Summary
- document how to pass `MKEPICAM_LIB` when building the wrapper
- clarify handling of shared vs static `mkepicam` library

## Testing
- `python mkepicam_wrapper/setup.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6842efde09f88333976d55577a33e35b